### PR TITLE
Add Supabase login form

### DIFF
--- a/app/(auth)/login/Login.tsx
+++ b/app/(auth)/login/Login.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+
+export default function Login() {
+  const router = useRouter();
+  const supabase = createClientComponentClient();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+    if (error) {
+      setError(error.message);
+    } else {
+      setError(null);
+      router.push('/');
+    }
+  };
+
+  return (
+    <form onSubmit={handleLogin} className="flex flex-col gap-4 max-w-sm mx-auto mt-8">
+      <input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="border rounded p-2"
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border rounded p-2"
+      />
+      {error && <p className="text-red-500">{error}</p>}
+      <button type="submit" className="bg-blue-600 text-white p-2 rounded">
+        Login
+      </button>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Login component with Tailwind form
- handle Supabase sign-in and error messaging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9af1186e0832b8123ba682e2d765d